### PR TITLE
redef zgrad for backward and forward compatibility

### DIFF
--- a/scratchai/attacks/attacks/deepfool.py
+++ b/scratchai/attacks/attacks/deepfool.py
@@ -8,7 +8,23 @@ import torch.nn as nn
 import numpy as np
 import copy
 
-from torch.autograd.gradcheck import zero_gradients as zgrad
+try:
+  from torch.autograd.gradcheck import zero_gradients as zgrad
+except ImportError:
+  import collections, torch
+  def zero_gradients(x):
+      if isinstance(x, torch.Tensor):
+          if x.grad is not None:
+              x.grad.detach_()
+              x.grad.zero_()
+      elif isinstance(x, collections.abc.Iterable):
+          for elem in x:
+              zero_gradients(elem)
+
+
+  def zero_gradients(i):
+      for t in iter_gradients(i):
+          t.zero_()
 
 
 __all__ = ['deepfool', 'DeepFool']

--- a/scratchai/attacks/attacks/deepfool.py
+++ b/scratchai/attacks/attacks/deepfool.py
@@ -22,10 +22,6 @@ except ImportError:
               zero_gradients(elem)
 
 
-  def zero_gradients(i):
-      for t in iter_gradients(i):
-          t.zero_()
-
 
 __all__ = ['deepfool', 'DeepFool']
 


### PR DESCRIPTION
Pytorch has removed the function `zero_gradients`. Redefining the same for forward compatibility.

```python
def zero_gradients(x):
    if isinstance(x, torch.Tensor):
        if x.grad is not None:
            x.grad.detach_()
            x.grad.zero_()
    elif isinstance(x, collections.abc.Iterable):
        for elem in x:
            zero_gradients(elem)
```  

References:

[1]https://github.com/pytorch/pytorch/blob/819d4b2b83fa632bf65d14f6af80a09e7476e87e/torch/autograd/gradcheck.py#L15
[2] https://discuss.pytorch.org/t/from-torch-autograd-gradcheck-import-zero-gradients/127462
[3] https://stackoverflow.com/questions/68419612/imorting-zero-gradients-from-torch-autograd-gradcheck

